### PR TITLE
display in tooltip on save instead of HTML popup

### DIFF
--- a/Commands/Save & Validate with ESLint.tmCommand
+++ b/Commands/Save & Validate with ESLint.tmCommand
@@ -27,17 +27,11 @@ fi
 	<string>@s</string>
 	<key>name</key>
 	<string>Save &amp; Validate with ESLint</string>
-	<key>outputCaret</key>
-	<string>afterOutput</string>
-	<key>outputFormat</key>
-	<string>html</string>
-	<key>outputLocation</key>
-	<string>newWindow</string>
+	<key>output</key>
+	<string>showAsTooltip</string>
 	<key>scope</key>
 	<string>source.js</string>
 	<key>uuid</key>
 	<string>E18003EA-CF71-4E5F-A504-C62C21877FF1</string>
-	<key>version</key>
-	<integer>2</integer>
 </dict>
 </plist>

--- a/Support/validate.py
+++ b/Support/validate.py
@@ -20,6 +20,7 @@ import tempfile
 import hashlib
 import shutil
 
+NUM_ERRORS_PREVIEW = 6
 
 def show_error_message(message):
     context = {
@@ -271,6 +272,31 @@ def validate(quiet=False):
 
         issues.append(issue)
 
+    # short response if quiet
+    if quiet:
+        num_issues = len(issues)
+        if num_issues == 0:
+            return
+
+        
+        message_lines = []
+        message_lines.append(
+            u'ESLint found {0} problem{1}. Run ESLint for more details.\r'
+            .format(num_issues, 's' if num_issues > 1 else '')
+        )
+
+        loop_to = min(num_issues, NUM_ERRORS_PREVIEW)
+        
+        if num_issues > NUM_ERRORS_PREVIEW:
+            message_lines.append('Preview:')
+        for issue in issues[:loop_to]:
+            message_lines.append(
+                '{line}:{character}\t{reason}'.format(**issue)
+            )
+
+        print('\r'.join(message_lines))
+        return
+        
     # normalize line numbers
     input_start_line = int(os.environ.get('TM_INPUT_START_LINE', 1)) - 1
     for issue in issues:

--- a/Support/validate.py
+++ b/Support/validate.py
@@ -123,7 +123,11 @@ def validate(quiet=False):
         path_parts.append('/usr/bin')
     if '/usr/local/bin' not in path_parts:
         path_parts.append('/usr/local/bin')
+    if os.environ.get('TM_PROJECT_DIRECTORY', None) is not None:
+        npm_bin = os.path.join(os.environ.get('TM_PROJECT_DIRECTORY'), 'node_modules', '.bin')
+        path_parts.insert(0, npm_bin)
     env['PATH'] = ':'.join(path_parts)
+    
 
     try:
         eslint = subprocess.Popen(

--- a/Support/validate.py
+++ b/Support/validate.py
@@ -89,6 +89,14 @@ def get_marker_directory():
     return markerDir
 
 
+def update_gutter_marks(issues):
+    mate = os.environ['TM_MATE']
+    file = os.environ['TM_FILEPATH']
+    subprocess.call([mate, '--clear-mark=warning', file])
+    for issue in issues:
+        subprocess.call([mate, '--set-mark=warning:{0}'.format(issue['reason']), '--line={0}'.format(issue['line']), file])
+
+
 def validate(quiet=False):
     # absolute path of this file, used to reference other files
     my_dir = os.path.abspath(os.path.dirname(__file__))
@@ -275,6 +283,9 @@ def validate(quiet=False):
             issue['shortname'] = m.group('shortname')
 
         issues.append(issue)
+
+    if 'TM_FILEPATH' in os.environ:
+        update_gutter_marks(issues)
 
     # short response if quiet
     if quiet:


### PR DESCRIPTION
Hey @natesilva, these are some sloppy changes I made to get errors on save to display in a tooltip instead of a popup. This is how [jslintmate](http://rondevera.github.io/jslintmate/) works and I find it more pleasant. 

Unfortunately I had to modify the `.tmcommand` file a bit more than I'd like, but couldn't find a way to get the tooltip to show w/o removing version: 2 from the plist. Curious about your thoughts on this.
