### PR TITLE
Only show tooltip with result summary on save.

### DIFF
--- a/Commands/Save & Validate with ESLint.tmCommand
+++ b/Commands/Save & Validate with ESLint.tmCommand
@@ -12,11 +12,11 @@
 set -f
 
 TPY=${TM_PYTHON:-python}
-HTML=$("${TPY}" "${TM_BUNDLE_SUPPORT}/validate.py" -q)
-if [[ "${HTML}" = "" ]]; then
+OUTPUT=$("${TPY}" "${TM_BUNDLE_SUPPORT}/validate.py" -q)
+if [[ "${OUTPUT}" = "" ]]; then
 	exit_discard
 else
-	echo ${HTML}
+	echo ${OUTPUT}
 fi
 </string>
 	<key>input</key>
@@ -30,9 +30,9 @@ fi
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>
-	<string>html</string>
+	<string>text</string>
 	<key>outputLocation</key>
-	<string>newWindow</string>
+	<string>toolTip</string>
 	<key>scope</key>
 	<string>source.js</string>
 	<key>uuid</key>

--- a/Support/validate.py
+++ b/Support/validate.py
@@ -88,6 +88,15 @@ def get_marker_directory():
     return markerDir
 
 
+def result_message(errorCount, warningCount):
+    parts = []
+    if errorCount > 0:
+        parts.append('{0} error{1}'.format(errorCount, 's' if errorCount > 1 else ''))
+    if warningCount > 0:
+        parts.append('{0} warning{1}'.format(warningCount, 's' if warningCount > 1 else ''))
+    return ', '.join(parts)
+
+
 def validate(quiet=False):
     # absolute path of this file, used to reference other files
     my_dir = os.path.abspath(os.path.dirname(__file__))
@@ -324,6 +333,10 @@ def validate(quiet=False):
         if not os.path.exists(context['markerFile']):
             if quiet:
                 return
+
+    if quiet:
+        print(result_message(context['errorCount'], context['warningCount']))
+        return
 
     # create the marker file
     markerFile = open(context['markerFile'], 'w+')


### PR DESCRIPTION
Similar to https://github.com/natesilva/javascript-eslint.tmbundle/pull/3 but shows really short summary only. Works great if combined with https://github.com/natesilva/javascript-eslint.tmbundle/pull/6 for having detailled validation information in form of gutter marks.

(Full validation output in dedicated window is still available via “Validate with ESLint” command.)
