### PR TITLE
encode html as utf-8 to allow unicode characters

### DIFF
--- a/Support/main.py
+++ b/Support/main.py
@@ -110,7 +110,7 @@ def full_report():
         context['warningCountString'] = '%s warnings' % warning_count
 
     html = ASHES_ENV.render('report.html', context)
-    print(html)
+    print(html.encode('utf-8'))
 
 
 def quiet():


### PR DESCRIPTION
The title says it all. Without this change I had the script fail on the `⏎` character, which is used by the eslint prettier plugin.